### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: twilio-python
+  annotations:
+    github.com/project-slug: marvin-corea-cvshealth/twilio-python
+spec:
+  type: other
+  lifecycle: unknown
+  owner: devsecops

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,9 +2,15 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: twilio-python
+  description: A Python module for communicating with the Twilio API and generating TwiML.
+  tags: 
+    - python
+    - sms
+    - twilio
   annotations:
     github.com/project-slug: marvin-corea-cvshealth/twilio-python
 spec:
-  type: other
-  lifecycle: unknown
+  type: sms
+  lifecycle: dev
   owner: devsecops
+  system: python


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Tanzu Application Platform software catalog](http://tap-gui.tkgi-apps.wnp.polaris.cvshealthcloud.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).